### PR TITLE
Allow to use CPP specified by the environment

### DIFF
--- a/rpcgen/cpp
+++ b/rpcgen/cpp
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# This script is used solely by rpcgen when run during the build.
+# It allows using CPP from the environment rather than a hardcoded path.
+
+exec ${CPP} "$@"

--- a/rpcsvc/Makefile.am
+++ b/rpcsvc/Makefile.am
@@ -12,5 +12,5 @@ nodist_rpcsvc_HEADERS = klm_prot.h nlm_prot.h rstat.h spray.h \
 	nfs_prot.h rquota.h sm_inter.h
 
 %.h: %.x
-	$(top_builddir)/rpcgen/rpcgen -h -o $@ $<
+	CPP='$(CC) -E -x c-header' $(top_builddir)/rpcgen/rpcgen -Y $(top_srcdir)/rpcgen -h -o $@ $<
 


### PR DESCRIPTION
Fix for https://github.com/thkukuk/rpcsvc-proto/issues/1. Idea taken from glibc (sunrpc/Makefile).