### PR TITLE
Remove historic _RPC_THREAD_SAFE_ preprocessor conditional

### DIFF
--- a/rpcgen/rpc_main.c
+++ b/rpcgen/rpc_main.c
@@ -1346,15 +1346,6 @@ parseargs (int argc, const char *argv[], struct commandline *cmd)
   cmd->Scflag = flag['C'];
   cmd->makefileflag = flag['M'];
 
-#ifndef _RPC_THREAD_SAFE_
-  if (mtflag || newstyle)
-    {
-      /* glibc doesn't support these flags.  */
-      f_print (stderr,
-	       _("This implementation doesn't support newstyle or MT-safe code!\n"));
-      return (0);
-    }
-#endif
   if (tirpcflag)
     {
       pmflag = inetdflag ? 0 : 1;    /* pmflag or inetdflag is always TRUE */


### PR DESCRIPTION
When the code was imported from glibc, the -D_RPC_THREAD_SAFE_
build flag was missed.