### PR TITLE
rpcgen: New clean rules for Makefile

### DIFF
--- a/rpcgen/rpc_main.c
+++ b/rpcgen/rpc_main.c
@@ -1020,7 +1020,8 @@ $(TARGETS_SVC.c) \n\n");
 $(LDLIBS) \n\n");
   f_print (fout, "$(SERVER) : $(OBJECTS_SVC) \n");
   f_print (fout, "\t$(LINK.c) -o $(SERVER) $(OBJECTS_SVC) $(LDLIBS)\n\n ");
-  f_print (fout, "clean:\n\t $(RM) core $(TARGETS) $(OBJECTS_CLNT) \
+  f_print (fout, "clean:\n\t $(RM) *.o $(CLIENT) $(SERVER)\n\n");
+  f_print (fout, "clean_all:\n\t $(RM) core $(TARGETS) $(OBJECTS_CLNT) \
 $(OBJECTS_SVC) $(CLIENT) $(SERVER)\n\n");
   close_output (mkfilename);
 


### PR DESCRIPTION
clean: remove .o and bins
clean_all: remove all the generated files

It is a bit annoying to edit the Makefile for this.
Usually source files are customized and we don't want to delete them.
