### PR TITLE
rpcgen: rpc_cout: silence format-nonliteral

### DIFF
--- a/rpcgen/rpc_cout.c
+++ b/rpcgen/rpc_cout.c
@@ -353,6 +353,7 @@ emit_program (const definition * def)
       }
 }
 
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 static void
 emit_union (const definition * def)
 {
@@ -430,6 +431,7 @@ emit_union (const definition * def)
 
   f_print (fout, "\t}\n");
 }
+#pragma GCC diagnostic warning "-Wformat-nonliteral"
 
 static void
 inline_struct (definition *def, int flag)


### PR DESCRIPTION
Silence format-nonliteral warning with #pragma GCC diagnostic ignored.

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>