### PR TITLE
Fix gettext infrastructure mismatch error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,9 @@ AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
 AM_GNU_GETTEXT([external])
+m4_ifndef([AM_GNU_GETTEXT_REQUIRE_VERSION],
+  [m4_define([AM_GNU_GETTEXT_REQUIRE_VERSION], [])])
+AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
 AM_GNU_GETTEXT_VERSION([0.19.8])
 
 AC_OUTPUT([Makefile rpcgen/Makefile rpcsvc/Makefile po/Makefile.in])


### PR DESCRIPTION
AM_GNU_GETTEXT_VERSION instructs autopoint/gettextize to use an exact
version of gettext infrastructure.

To handle version upgrades gettext-0.19.6 added
AM_GNU_GETTEXT_REQUIRE_VERSION which instructs these to use the latest
available infrastructure which satisfies a version requirement.