### PR TITLE
fix rpcgen build on macos arm64

### DIFF
--- a/rpcgen/nls.h
+++ b/rpcgen/nls.h
@@ -1,0 +1,27 @@
+/* 
+ * 2006-06-08 Amit Gud <agud@redhat.com>
+ * - Copied to nfs-utils/support/include from util-linux/mount
+ */
+
+#ifndef LOCALEDIR
+#define LOCALEDIR "/usr/share/locale"
+#endif
+
+#ifdef ENABLE_NLS
+# include <libintl.h>
+# define _(Text) gettext (Text)
+# ifdef gettext_noop
+#  define N_(String) gettext_noop (String)
+# else
+#  define N_(String) (String)
+# endif
+#else
+# undef bindtextdomain
+# define bindtextdomain(Domain, Directory) /* empty */
+# undef textdomain
+# define textdomain(Domain) /* empty */
+# define _(Text) (Text)
+# define N_(Text) (Text)
+#endif
+
+

--- a/rpcgen/rpc_main.c
+++ b/rpcgen/rpc_main.c
@@ -42,7 +42,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
-#include <libintl.h>
 #include <locale.h>
 #include <ctype.h>
 #include <sys/types.h>
@@ -54,6 +53,7 @@
 #include "rpc_util.h"
 #include "rpc_scan.h"
 #include "proto.h"
+#include "nls.h"
 
 #ifndef _
 #define _(String) gettext (String)
@@ -61,6 +61,12 @@
 
 #define EXTEND	1		/* alias for TRUE */
 #define DONT_EXTEND	0	/* alias for FALSE */
+
+#ifdef __APPLE__
+# if __DARWIN_ONLY_64_BIT_INO_T
+#  define stat64 stat
+# endif
+#endif
 
 struct commandline
   {

--- a/rpcgen/rpc_scan.c
+++ b/rpcgen/rpc_scan.c
@@ -37,11 +37,11 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
-#include <libintl.h>
 #include "rpc_scan.h"
 #include "rpc_parse.h"
 #include "rpc_util.h"
 #include "proto.h"
+#include "nls.h"
 
 #ifndef _
 #define _(String) gettext (String)


### PR DESCRIPTION
1. __DARWIN_ONLY_64_BIT_INO_T is true on macos arm64 so struct stat64
and stat64() are not available. This patch defines stat64 as stat if
__DARWIN_ONLY_64_BIT_INO_T is true

2. Added libintl/gettext wrapper (nls.h) from nfs-kernel-server/tools/rpcgen
 to fix compile time (linker) issues on macos arm64

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>